### PR TITLE
Fix the meteor link in README.md.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# .gitignore
+# vim/gedit backup file
+*~
+
+# merge conflict files
+*.rej
+*.orig
+
+# vim buffer files
+*.swp
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCAS Base
 
-This project is powered by [Meteor](www.meteor.com), a fantastic javascript framework.
+This project is powered by [Meteor](https://www.meteor.com), a fantastic javascript framework.
 Not finished yet, I'm still working on it.
 
 Packages Used:


### PR DESCRIPTION
现在的 README.md 中的 meteor 链接默认指向了

https://github.com/CCharlieLi/OpenCAS-Base/blob/master/www.meteor.com

这可能不是你想要的 :-P
